### PR TITLE
Update nodemailer and expose every option of createTransport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -56,6 +56,9 @@ module.exports = function Email (sails) {
         transport = {
           sendMail: function(options, cb) {
 
+            // Add sent timestamp
+            options.sentAt = new Date();
+
             // First check the .tmp directory exists
             fs.exists(path.join(sails.config.appPath, '.tmp'), function(status) {
               if(!status) {

--- a/index.js
+++ b/index.js
@@ -36,11 +36,6 @@ module.exports = function Email (sails) {
       var obj = {};
       self.configKey = (sails.config.hooks['sails-hook-email'] && sails.config.hooks['sails-hook-email'].configKey) || 'email';
       obj[self.configKey] = {
-        service: 'Gmail',
-        auth: {
-          user: 'myemailaddress@gmail.com',
-          pass: 'mypassword'
-        },
         templateDir: path.join(__dirname, '../../views/emailTemplates'),
         from: 'noreply@login.com',
         testMode: true
@@ -82,13 +77,7 @@ module.exports = function Email (sails) {
         try {
 
           // create reusable transport method (opens pool of SMTP connections)
-          transport = nodemailer.createTransport('SMTP',{
-            service: sails.config[self.configKey].service,
-            auth: {
-              user: sails.config[self.configKey].auth.user,
-              pass: sails.config[self.configKey].auth.pass
-            }
-          });
+          transport = nodemailer.createTransport(sails.config[self.configKey]);
 
           return cb();
         }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "ejs": "^1.0.0",
-    "nodemailer": "0.7.1"
+    "nodemailer": "~1.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Only well-known services are permitted.
With this change is possible to configure a private smtp server.

Added sent timestamp to testMode file output.
