### PR TITLE
Make send() callback optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Parameter      | Type                | Details
 template       | ((string))          | Relative path from `templateDir` (see "Configuration" below) to a folder containing email templates.
 data           | ((object))          | Data to use to replace template tokens
 options        | ((object))          | Email sending options (see [Nodemailer docs](https://github.com/andris9/Nodemailer/blob/v1.3.4/README.md#e-mail-message-fields))
-cb             | ((function))        | Callback to be run after the email sends (or if an error occurs).
+cb             | ((function))        | Callback to be run after the email sends (or if an error occurs). Optional.
 
 ### Configuration
 

--- a/index.js
+++ b/index.js
@@ -137,15 +137,16 @@ module.exports = function Email(sails) {
 
     /**
      * Send an email.
-     * @param  {Sting}    template (a named template to render)
-     * @param  {Object}   data (data to pass into the template)
-     * @param  {Object}   options (email options including to, from, etc)
-     * @param  {Function} cb
+     *
+     * @param  {Sting}      template (a named template to render)
+     * @param  {Object}     data (data to pass into the template)
+     * @param  {Object}     options (email options including to, from, etc)
+     * @param  {Function?}  cb
      */
-
     send: function (template, data, options, cb) {
 
       data = data || {};
+      cb = cb || defaultCb;
       // Turn off layouts by default
       if (typeof data.layout === 'undefined') data.layout = false;
 
@@ -205,3 +206,19 @@ module.exports = function Email(sails) {
 
   };
 };
+
+/**
+ * Default send callback
+ *
+ * If user does not provide their own callback, we will use this one as a fallback
+ *
+ * @param  {Error}    err         Instance of Error object (if any)
+ * @param  {Object}   sendEmail   Information about the email just sent
+ * @return {void}
+ */
+function defaultCb (err, sendEmail) {
+
+  if (err) {
+    sails.log.error('Failed to send email:', err)
+  }
+}


### PR DESCRIPTION
Usually I just log to console when an error occurs during email sending. Not sure how other people deal with email errors, but I guess this provides a sane default to keep the codebase simple.

What do you think?
